### PR TITLE
Stop firefox's find-as-you-type from interfering with WSAD movement, by ...

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -255,6 +255,14 @@ function initEvents() {
             playerMover.jump();
         }
         pressed[event.keyCode] = true;
+        if (event.keyCode == 'W'.charCodeAt(0) ||
+            event.keyCode == 'S'.charCodeAt(0) ||
+            event.keyCode == 'A'.charCodeAt(0) ||
+            event.keyCode == 'D'.charCodeAt(0) ||
+            event.keyCode == 'R'.charCodeAt(0) ||
+            event.keyCode == 32) {
+            event.preventDefault();
+        }
     }, false);
     
     document.addEventListener("keypress", function(event) {


### PR DESCRIPTION
...calling preventDefault on the event object when one of the action keys is pressed.
