### PR TITLE
Allow ctrl-W to close the tab/window.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -255,12 +255,12 @@ function initEvents() {
             playerMover.jump();
         }
         pressed[event.keyCode] = true;
-        if (event.keyCode == 'W'.charCodeAt(0) ||
-            event.keyCode == 'S'.charCodeAt(0) ||
-            event.keyCode == 'A'.charCodeAt(0) ||
-            event.keyCode == 'D'.charCodeAt(0) ||
-            event.keyCode == 'R'.charCodeAt(0) ||
-            event.keyCode == 32) {
+        if ((event.keyCode == 'W'.charCodeAt(0) ||
+             event.keyCode == 'S'.charCodeAt(0) ||
+             event.keyCode == 'A'.charCodeAt(0) ||
+             event.keyCode == 'D'.charCodeAt(0) ||
+             event.keyCode == 'R'.charCodeAt(0) ||
+             event.keyCode == 32) && !e.ctrlKey) {
             event.preventDefault();
         }
     }, false);


### PR DESCRIPTION
This means that ctrl can't be used as a movement modifier key, but
that's better than forcing the user to keep the current tab open.
