### PR TITLE
info_player_deathmatch entity angle absense fix

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -166,7 +166,7 @@ function respawnPlayer(index) {
 
         playerMover.velocity = [0,0,0];
 
-        zAngle = -spawnPoint.angle * (3.1415/180) + (3.1415*0.5); // Negative angle in radians + 90 degrees
+        zAngle = -(spawnPoint.angle || 0) * (3.1415/180) + (3.1415*0.5); // Negative angle in radians + 90 degrees
         xAngle = 0;
     }
 }

--- a/js/q3bsp_worker.js
+++ b/js/q3bsp_worker.js
@@ -598,7 +598,7 @@ q3bsp.compileMap = function(verts, faces, meshVerts, lightmaps, shaders, tessela
     }
     
     // Compile vert list
-    var vertices = new Array(verts.length*10);
+    var vertices = new Array(verts.length*14);
     var offset = 0;
     for(var i = 0; i < verts.length; ++i) {
         var vert = verts[i];

--- a/js/q3bsp_worker.js
+++ b/js/q3bsp_worker.js
@@ -83,7 +83,15 @@ q3bsp.parse = function(src, tesselationLevel) {
     
     var header = q3bsp.readHeader(src);
     
-    if(header.tag != 'IBSP' && header.version != 46) { return; } // Check for appropriate format
+    // Check for appropriate format
+    if(header.tag != 'IBSP' || header.version != 46) {
+        postMessage({
+            type: 'status',
+            message: 'Incompatible BSP version.'
+        });
+
+        return;
+    }
     
     // Read map entities
     q3bsp.readEntities(header.lumps[0], src);


### PR DESCRIPTION
Sometimes the entities can have no angle property set at all, means that if you create in editior, for example, "info_player_deathmatch" entity and won't change its angle, the editor won't save the angle property in bsp, thus the zangle will be NaN and we wont see the world.