### PR TITLE
properly update express using required middlewares

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "url": "https://github.com/toji/webgl-quake3/issues"
   },
   "dependencies": {
-    "express": "3.4.8"
+    "express": "4.17.1",
+    "serve-index": "^1.9.1",
+    "serve-static": "^1.14.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,13 +4,15 @@
 // http://expressjs.com/
 
 // Then simply run "node server" from the command line in this directory
-// at that point you can view the demo by visiting http://localhost:900/index.html
+// at that point you can view the demo by visiting http://localhost:9000/index.html
 
 var express = require('express');
+var serveStatic = require('serve-static');
+var serveIndex = require('serve-index');
 
 var app = express();
-app.use(express.static(__dirname));
-app.use(express.directory(__dirname));
+app.use(serveStatic(__dirname));
+app.use(serveIndex(__dirname));
 app.listen(9000);
 
 console.log('Server is now listening on port 9000');


### PR DESCRIPTION
Hi,
This is my way of saying thank you for this amazing project.

This PR updates express to its last version, which from v4 requires static middlewares to be imported using their independent packages as they are no longer part of the express core. 